### PR TITLE
add single file section tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,12 @@ Some shopify liquid object attributes contain objects. These tags will apply hig
 - `{{ all_products }}`
 - `{{ country_option_tags }}`
 
+## Single File Section Tags
+
+This extension also includes 4 additional syntax tags. **These tags are not apart of the liquid language** and are used as code block reference strings when developing single file sections.
+
+- `{% <json> %}`
+- `{% <html>%}`
+- `{% <style> %}`
+- `{% <script> %}`
+

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "publisher": "sissel",
     "icon": "images/logo.png",
     "author": "Nikolas Savvidis <nicos@gmx.com>",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "keywords": [
 		"liquid",
 		"shopify",

--- a/syntaxes/liquid.json
+++ b/syntaxes/liquid.json
@@ -10,6 +10,9 @@
 			"include": "#section_code_blocks"
 		},
 		{
+			"include": "#single_file_sections"
+		},
+		{
 			"name": "comment.block.liquid",
 			"begin": "{%-?\\s*comment\\s*-?%}",
 			"end": "{%-?\\s*endcomment\\s*-?%}"
@@ -175,6 +178,91 @@
 				{
 					"name": "entity.name.tag.liquid",
 					"match": "(?<={%-)\\s*(\\w+)"
+				}
+			]
+		},
+		"single_file_sections": {
+			"patterns": [
+				{
+					"match": "{%\\s(<|</)\\s*(html)\\s*(>)\\s%}",
+					"captures": {
+						"1": {
+							"name": "support.class.liquid"
+						},
+						"2": {
+							"name": "entity.name.tag.liquid"
+						},
+						"3": {
+							"name": "support.class.liquid"
+						}
+					}
+				},
+				{
+					"name": "meta.embedded.json.liquid",
+					"begin": "{%\\s(<)\\s*(json)\\s*(>)\\s%}",
+					"end": "{%\\s(</)\\s*(json)\\s*(>)\\s%}",
+					"captures": {
+						"1": {
+							"name": "support.class.liquid"
+						},
+						"2": {
+							"name": "entity.name.tag.liquid"
+						},
+						"3": {
+							"name": "support.class.liquid"
+						}
+					},
+					"patterns": [
+						{
+							"include": "text.html.liquid"
+						},
+						{
+							"name": "string.quoted.double.liquid",
+							"match": "(?=)(\".*\"(\\s:|:))"
+						}
+					]
+				},
+				{
+					"name": "meta.embedded.js.liquid",
+					"begin": "{%\\s(<)\\s*(script)\\s*(>)\\s%}",
+					"end": "{%\\s(</)\\s*(script)\\s*(>)\\s%}",
+					"captures": {
+						"1": {
+							"name": "support.class.liquid"
+						},
+						"2": {
+							"name": "entity.name.tag.liquid"
+						},
+						"3": {
+							"name": "support.class.liquid"
+						}
+					},
+					"patterns": [
+						{
+							"include": "source.js"
+						}
+					]
+				},
+				{
+					"name": "meta.embedded.style.liquid",
+					"begin": "{%\\s(<)\\s*(style)\\s*(>)\\s%}",
+					"end": "{%\\s(</)\\s*(style)\\s*(>)\\s%}",
+					"captures": {
+						"1": {
+							"name": "support.class.liquid"
+						},
+						"2": {
+							"name": "entity.name.tag.liquid"
+						},
+						"3": {
+							"name": "support.class.liquid"
+						}
+					},
+					"patterns": [
+						{
+							"include": "source.css.scss"
+						}
+					]
 				}
 			]
 		},

--- a/test.liquid
+++ b/test.liquid
@@ -1,3 +1,61 @@
+{% <json> %}
+  {
+    "align": {{ section.settings.banner_align  }},
+    "buttons": {{ section.settings.banner_buttons  }},
+    "data": [
+      {%- for block in section.blocks -%}
+        {
+          "text": {{ block.settings.text | json }},
+          "href": {{ block.settings.link | json }}
+        }
+      {%- unless forloop.last -%},{%- endunless -%}
+      {%- endfor -%}
+    ]
+  }
+{% </json> %}
+
+{% <html> %}
+
+{% for tag in collection.all_tags %}
+  {% if current_tags contains tag %}
+    <li class="active">
+      {{ tag | link_to_remove_tag: tag }}
+    </li>
+  {% else %}
+    <li>
+      {{ tag | link_to_add_tag: tag }}
+    </li>
+  {% endif %}
+{% endfor %}
+
+
+{% </html> %}
+
+{% <style> %}
+
+  .foo {
+    position: relative;
+  }
+
+  .bar {
+    height: 50px;
+    width: 100%;
+  }
+
+{% </style> %}
+
+{% <script> %}
+
+  function(){
+
+  }
+
+{% </script> %}
+
+
+{% enddata %}
+
+
 {% stylesheet 'scss' %}
 
   $position: relative;


### PR DESCRIPTION
Adding 4 additional syntax tags. These tags are used as code block reference strings when developing single file sections (SFS). 

- `{% <json> %}`
- `{% <html>%}`
- `{% <style> %}`
- `{% <script> %}`

#### PLEASE NOTE
These tags are not apart of the liquid language. These are used internally for theme development. 